### PR TITLE
Fixes side to side wiggle on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,8 +254,6 @@
 
         <hr class="featurette-divider">
 
-    </div>
-
     <!-- Footer -->
     <footer class="footer">
         <div class="row">
@@ -264,6 +262,7 @@
             </div>
         </div>
     </footer>
+</div>
 
     <!-- /.container -->
 


### PR DESCRIPTION
resolves #6 

# Problem

On mobile we currently have something causing the page to be wider than the device. It looked like the issue was with the navbar but it turns out it was the footer. Specifically it's using a predefined css class called ```row```. Row by default has margins = -15 which makes it's width wider than the page should be and affects the entire page.

# Solution

fix the footer to be the proper width and the entire site will now have the proper width

# Implementation

I decided just to nest the footer in with the rest of the page under the ```<div class="container">```. This works fine but if we want the footer to actually be a separate component we could also add another layer to it by putting a new ```<div class="container">``` as a parent of ```<div class="row">``` which should also fix the issue.

# Reference

This is a minor change and a screenshot isn't really needed but here it is anyways

![image](https://user-images.githubusercontent.com/8846353/28250574-72488914-6a31-11e7-9007-0faebcf8998e.png)


