### PR TITLE
Fixes hamburger menu auto collapse for mobile

### DIFF
--- a/js/devclubJS.js
+++ b/js/devclubJS.js
@@ -18,3 +18,14 @@ jQuery('html').bind('click', function(e) {
         }
     }
 });
+
+//navbar - collapse when clicking outside menu
+jQuery('html').bind('touchstart', function(e) {
+    if(jQuery(e.target).closest('.navbar').length == 0) {
+        // click happened outside of .navbar, so hide
+        var opened = jQuery('.navbar-collapse').hasClass('collapse in');
+        if ( opened === true ) {
+            jQuery('.navbar-collapse').collapse('hide');
+        }
+    }
+});


### PR DESCRIPTION
resolves #5 

# Problem

When you click outside of the expanded hamburger menu it was not collapsing. It created a strange experience where you could navigate the site with the menu stuck open, blocking a large portion of the screen. It turned out to be an issue with how clicks are handled.

# Solution

On mobile a click is pretty strictly defined, you would pretty much have to tap away from the menu to get it to work. What we want instead is a "touchstart" so you can touch and drag your finger around etc and it will still clear the menu if that initial touch falls outside of the menu.

# Implementation

I literally just copied the ```click bind``` js function and added another binding to ```touchstart```. This works as expected without screwing up what was originally in place for desktop.

# Testing

I was able to replicate the original behaviour in my browser simply by clicking and dragging rather than just clicking. I've only tested it in my browser but everything seems to be working as expected.

# References

no references necessary 